### PR TITLE
chore: reduce go mod compiler version requirement down to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/nbio/xml
 
-go 1.21.1
+go 1.21


### PR DESCRIPTION
resolves #12