### PR TITLE
Fix indentation issue with SelfClosingElement

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -215,6 +215,7 @@ func (enc *Encoder) EncodeToken(t Token) error {
 		if err := p.writeStart((*StartElement)(&t), true); err != nil {
 			return err
 		}
+		p.writeIndent(-1)
 	case StartElement:
 		if err := p.writeStart(&t, false); err != nil {
 			return err

--- a/xml_test.go
+++ b/xml_test.go
@@ -2031,3 +2031,33 @@ func TestHTMLAutoClose(t *testing.T) {
 		}
 	}
 }
+
+// PR #20
+// Indentation not correct after self closing element
+func TestSelfClosingIndentation(t *testing.T) {
+	must := func(err error, msg string) {
+		if err != nil {
+			t.Errorf("%s: error = %v", msg, err)
+		}
+	}
+	// Arrange
+	writer := strings.Builder{}
+	encoder := NewEncoder(&writer)
+	encoder.Indent("", "   ")
+
+	// Act
+	must(encoder.EncodeToken(StartElement{Name: Name{Local: "RootElement"}}), "start root element")
+	must(encoder.EncodeToken(SelfClosingElement{Name: Name{Local: "Child1"}}), "child1")
+	must(encoder.EncodeToken(SelfClosingElement{Name: Name{Local: "Child2"}}), "child2")
+	must(encoder.EncodeToken(EndElement{Name: Name{Local: "RootElement"}}), "end root element")
+	must(encoder.Flush(), "flush")
+
+	// Assert
+	expected := `<RootElement>
+   <Child1/>
+   <Child2/>
+</RootElement>`
+	if writer.String() != expected {
+		t.Errorf("output mismatch:\nhave: %#v\nwant: %#v", writer.String(), expected)
+	}
+}


### PR DESCRIPTION
Use of SelfClosingElement gets the indentation wrong
This is because EndElement handles this but it is not done for StartElement.
Very tiny change to fix this - call indent method after SelfClosingElement has been written.