### PR TITLE
Removed infinite loop

### DIFF
--- a/xml.go
+++ b/xml.go
@@ -1035,11 +1035,6 @@ Input:
 			d.ungetc('<')
 			break Input
 		}
-		// This occurs only for an unquoted attr name.
-		if b == '>' && !cdata && quote < 0 { // Possible end of tag reached
-			d.ungetc('>') // Leaving end of tag available
-			break         // returning text
-		}
 		if quote >= 0 && b == byte(quote) {
 			break Input
 		}


### PR DESCRIPTION
Hey, 
I encountered a problem when trying to parse docs where `>` occurred inside of a tag body as normal text.
Inside the go package it was already fixed so i ported the changes over.

https://github.com/golang/go/blob/master/src/encoding/xml/xml.go#L1027